### PR TITLE
Fix compilation error: `<=<` not in scope

### DIFF
--- a/src/Control/Monad/Validate/Internal.hs
+++ b/src/Control/Monad/Validate/Internal.hs
@@ -5,6 +5,7 @@
 -- "Control.Monad.Validate" for the public interface.
 module Control.Monad.Validate.Internal where
 
+import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Base
 import Control.Monad.Catch


### PR DESCRIPTION
Hi,
Thanks for creating and maintaining this library!

I was trying to use it in my project, but ran into an error during `cabal build` (tested with `GHC 9.2.6`):
```
src/Control/Monad/Validate/Internal.hs:534:54: error:
    • Variable not in scope:
        (<=<)
          :: (Either e1 a0 -> m0 a0)
             -> (ValidateT e0 m1 a1 -> m1 (Either e0 a1))
             -> ValidateT e1 m a
             -> m a
    • Perhaps you meant one of these:
        ‘=<<’ (imported from Prelude), ‘<=’ (imported from Prelude)
    |
534 | validateToErrorWith f = either (throwError . f) pure <=< runValidateT
    |                                                      ^^^
```

The error seems to occur since version `1.2.0.0` (when the erroneous `validateToErrorWith` function was introduced).

After adding an import for `Control.Monad`, I no longer get the error.