### PR TITLE
Add `MonadFix` instance to `ValidateT`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.1.0 [to be released]
+
+- Added `MonadFix` instance for `ValidateT`.
+
 # 1.2.0.2 [2023-08-17]
 
 - Added support for mtl 2.3.

--- a/src/Control/Monad/Validate/Internal.hs
+++ b/src/Control/Monad/Validate/Internal.hs
@@ -10,6 +10,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Base
 import Control.Monad.Catch
 import Control.Monad.Except
+import Control.Monad.Fix
 import Control.Monad.Reader.Class
 import Control.Monad.State.Strict
 import Control.Monad.Trans.Control
@@ -302,6 +303,10 @@ instance (Monad m) => Monad (ValidateT e m) where
 instance MonadTrans (ValidateT e) where
   lift m = ValidateT (lift $ lift m)
   {-# INLINE lift #-}
+
+instance (MonadFix m) => MonadFix (ValidateT e m) where
+  mfix f = ValidateT $ mfix (\x -> getValidateT (f x))
+  {-# INLINE mfix #-}
 
 instance (MonadIO m) => MonadIO (ValidateT e m) where
   liftIO = lift . liftIO


### PR DESCRIPTION
### Description

Sorry for this quick PR out of the blue! It just adds a `MonadFix` instance to `ValidateT`, based on the instance for the underlying `StateT`. AFAICT this should be correct, given that the instance on `StateT` is.

### Open questions

- should this be accompanied by a test? i don't think that's necessary, in the sense that it doesn't change the semantics of the library?
- should this PR be bumping the version number?
- should this PR include a Chanelog entry?

Thanks!